### PR TITLE
优化脚本逻辑，修复已知 bugs

### DIFF
--- a/include/btree.cc
+++ b/include/btree.cc
@@ -59,7 +59,7 @@ bool is_same_tree(TreeNode *root1, TreeNode *root2)
     return false;
 }
 
-Tree::Tree(std::initializer_list<int> il) : q(il)
+Tree::Tree(std::initializer_list<int> il) : q(il), root(nullptr)
 {
     if (q.empty())
         return;

--- a/leetcode
+++ b/leetcode
@@ -8,8 +8,10 @@
 # @brief    
 # @version  0.0.1
 # 
-# Last Modified:  2019-05-21
 # Modified By:    Jiang Yang (pokerpoke@qq.com)
+#
+# Last Modified:  2023-11-08
+# Modified By:    HangX-Ma (contour.9x@gmail.com)
 # 
 ################################################################################
 set -e
@@ -20,11 +22,8 @@ CMAKE_SOURCE_DIR=$(dirname $(readlink -f $0))
 CMAKE_SOURCE_DIR=$(pwd)
 cd ${CMAKE_SOURCE_DIR}
 
-if [ ! -d ./build ] 
-then
-   mkdir build 
-fi
+cmake -B build
+cmake --build build -j`nproc`
 
-cd build && cmake ..  && make $1 -j8 && cd src 
-
-./$1
+file_path=$1
+./build/${file_path%%\.cc}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 aux_source_directory(. EXECUTABLE)
 foreach(T_FILE_NAME ${EXECUTABLE})
     # get solution id and solution name
-    string(REGEX REPLACE ".cc" "" EXECUTABLE_NAME ${T_FILE_NAME})
-    string(REGEX REPLACE "\.\/" "" EXECUTABLE_NAME ${EXECUTABLE_NAME})
+    string(REGEX REPLACE "\\.\\c\\c" "" EXECUTABLE_NAME ${T_FILE_NAME})
+    string(REGEX REPLACE "\\.\/" "" EXECUTABLE_NAME ${EXECUTABLE_NAME})
     add_executable(${EXECUTABLE_NAME} ${T_FILE_NAME})
     target_link_libraries(
         ${EXECUTABLE_NAME}


### PR DESCRIPTION
- 增加 `root` 变量初始化赋值
> `btree.cc` 中 `root` 变量在 `q.empty()` 条件满足时会变为野指针
- 修复了 `CMakeList.txt` 正则匹配的错误
> 如文件名为 `28.find_the_index_of_the_first_occurrence_in_a_string.cc`，原版本正则表达式 `.` 表示匹配一个字符，因而文件名会被错误改为 `28.find_the_index_of_the_first_urrence_in_a_string`
- 优化 `leetcode` 脚本逻辑
> 后续使用方式可变更为 `./leetcode src/PROBLEM_NAME.cc`，方便直接自动补全